### PR TITLE
hexer shouldn't overwrite the headSep option when color is set

### DIFF
--- a/hex_transform.js
+++ b/hex_transform.js
@@ -1,5 +1,6 @@
 "use strict";
 
+var copyInto = require('xtend/immutable');
 var extendInto = require('xtend/mutable');
 var util = require('util');
 var Transform = require('readable-stream').Transform;
@@ -12,7 +13,11 @@ function HexTransform(options) {
     // istanbul ignore next
     if (!options) options = {};
     // istanbul ignore if
-    if (options.colored) extendInto(options, render.coloredOptions);
+    if (options.colored) {
+        var newOptions = copyInto(render.coloredOptions);
+        extendInto(newOptions, options);
+        options = newOptions;
+    }
     Transform.call(this, options);
     var self = this;
     self.options = options;


### PR DESCRIPTION
r @jcorbin
cc @kriskowal 

This changes two things:
1. headSep won't be overwritten by the default setting when the color option is set.
2. the parameter(i.e. options) passed to HexTransform won't be modified.
