### PR TITLE
remove readable-stream dependency

### DIFF
--- a/hex_spy.js
+++ b/hex_spy.js
@@ -1,5 +1,5 @@
 var util = require('util');
-var Transform = require('readable-stream').Transform;
+var Transform = require('stream').Transform;
 var ChunkedHexTransform = require('./chunked_hex_transform');
 
 module.exports = HexSpy;

--- a/hex_transform.js
+++ b/hex_transform.js
@@ -2,7 +2,7 @@
 
 var extend = require('xtend');
 var util = require('util');
-var Transform = require('readable-stream').Transform;
+var Transform = require('stream').Transform;
 var render = require('./render');
 
 function HexTransform(options) {

--- a/package.json
+++ b/package.json
@@ -27,7 +27,6 @@
     "ansi-color": "^0.2.1",
     "minimist": "^1.1.0",
     "process": "^0.10.0",
-    "readable-stream": "^1.0.33",
     "xtend": "^4.0.0"
   },
   "devDependencies": {

--- a/test/chunked.js
+++ b/test/chunked.js
@@ -1,4 +1,4 @@
-var PassThrough = require('readable-stream').PassThrough;
+var PassThrough = require('stream').PassThrough;
 var test = require('tape');
 var extendInto = require('xtend/mutable');
 var expectReadableStream = require('./lib/expect_readable_stream');

--- a/test/spy.js
+++ b/test/spy.js
@@ -1,4 +1,4 @@
-var PassThrough = require('readable-stream').PassThrough;
+var PassThrough = require('stream').PassThrough;
 var test = require('tape');
 var expectReadableStream = require('./lib/expect_readable_stream');
 


### PR DESCRIPTION
Trying to clean up dependency count in tchannel-node.
This gets rid of another copy of readable-stream.

Ideally we somehow decouple hexer from bufrw as its not
needed in production code.

r: @jcorbin @kriskowal
