### PR TITLE
Fixed FusionJS issue 622 by using ansi-colors instead of ansi-color

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -49,3 +49,4 @@ coverage/
 ehthumbs.db
 Icon?
 Thumbs.db
+package-lock.json

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "hexer": "./cli.js"
   },
   "dependencies": {
-    "ansi-color": "^0.2.1",
+    "ansi-colors": "^4.1.1",
     "minimist": "^1.1.0",
     "process": "^0.10.0",
     "xtend": "^4.0.0"

--- a/render.js
+++ b/render.js
@@ -1,6 +1,6 @@
 'use strict';
 
-var color = require('ansi-color').set;
+var color = require('ansi-colors');
 
 function pad(c, s, width) {
     while (s.length < width) s = c + s;
@@ -24,7 +24,7 @@ function renderColoredHuman(c) {
     if (c > 0x1f && c < 0x7f) {
         return String.fromCharCode(c);
     } else {
-        return color('.', 'black+bold');
+        return color.black.bold('.');
     }
 }
 
@@ -39,7 +39,7 @@ function stripColor(str) {
     }
 }
 
-module.exports.coloredHeadSep = color(':', 'cyan') + ' ';
+module.exports.coloredHeadSep = color.cyan(':') + ' ';
 
 module.exports.coloredOptions = {
     headSep: module.exports.coloredHeadSep,

--- a/test/colored.js
+++ b/test/colored.js
@@ -8,7 +8,7 @@ test('colored options', function t(assert) {
     assert.deepEqual(hex(buf, {
         colored: true
     }).split(/\n/), [
-        '00\x1b[36m:\x1b[0m 6162 63                                  abc'
+        '00\x1b[36m:\x1b[39m 6162 63                                  abc'
     ], 'expected basic output');
 
     assert.deepEqual(hex(buf, {
@@ -22,7 +22,7 @@ test('colored options', function t(assert) {
     assert.deepEqual(hex(buf, {
         colored: true
     }).split(/\n/), [
-        '00\x1b[36m:\x1b[0m 00                                       \x1b[30m\x1b[1m.\x1b[0m'
+        '00\x1b[36m:\x1b[39m 00                                       \x1b[30m\x1b[1m.\x1b[22m\x1b[39m'
     ], 'expected human rendering');
 
     buf = Buffer([0]);
@@ -32,7 +32,7 @@ test('colored options', function t(assert) {
             return (c > 0x1f && c < 0x7f) ? String.fromCharCode(c) : '.';
         }
     }).split(/\n/), [
-        '00\x1b[36m:\x1b[0m 00                                       .'
+        '00\x1b[36m:\x1b[39m 00                                       .'
     ], 'expected ability to override renderHuman');
 
     assert.end();


### PR DESCRIPTION
Related: https://github.com/fusionjs/fusion-cli/issues/622

ansi-color uses octal notation for colors that seems to cause errors when using Babel's es2015 preset which uses strict mode for Javascript. This strict mode doesn't allow hex codes starting with `\0xy`, it must start with `\u0xy` instead. Instead of attempting to fix very old code within ansi-color, I have changed the package dependency to use a better supported utility called ansi-colors.

While making this decision to use ansi-colors, we also could have used chalk. Both are well used and supported, but ansi-colors was a better near drop-in replacement to ansi-color. This change makes the external contract the same, so users of hexer will notice no difference and won't need to change their code at all besides the package version.

It's entirely possible to create a patch or minor version update since this is an internal change that doesn't affect external code.